### PR TITLE
Add bminusl/ulauncher-jd in Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ j.
 
 ## Desktop utilities
 
+### Linux
+
+- [bminusl/ulauncher-jd](https://github.com/bminusl/ulauncher-jd): [Ulauncher](https://ulauncher.io/) extension for the Johnny Decimal filing system. 
+
 ### macOS
 
 - [bsag/alfred-jd](https://github.com/bsag/alfred-jd): First! 🥳 An [Alfred](https://alfredapp.com) workflow to jump straight to the JD folders on your filesystem.


### PR DESCRIPTION
This is an extension to [Ulauncher](https://ulauncher.io/), an application launcher for Linux.

As stated in its `README.md`, the project is currently in its early phase and lacks feature. But I am working on it. :+1: 